### PR TITLE
Removing non-key attributes from attribute definitions because AWS will not have it

### DIFF
--- a/non-prod.yaml
+++ b/non-prod.yaml
@@ -14,22 +14,8 @@ Resources:
       AttributeDefinitions:
         - AttributeName: "id"
           AttributeType: S
-        - AttributeName: "type"
-          AttributeType: S
-        - AttributeName: "title"
-          AttributeType: S
-        - AttributeName: "generatedTitle"
-          AttributeType: S
-        - AttributeName: "createdAt"
-          AttributeType: N
         - AttributeName: "updatedAt"
           AttributeType: N
-        - AttributeName: "participants"
-          AttributeType: L
-        - AttributeName: "summary"
-          AttributeType: S
-        - AttributeName: "messages"
-          AttributeType: L
       KeySchema:
         - AttributeName: "id"
           KeyType: HASH


### PR DESCRIPTION
Removing non-key attributes from attribute definitions because AWS will not have it